### PR TITLE
fix: provide database connection options to fx container for circuit breaker

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,10 +43,16 @@ func newServeCommand() *cobra.Command {
 				return err
 			}
 
+			connectionOptions, err := bunconnect.ConnectionOptionsFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
 			listen, _ := cmd.Flags().GetString(listenFlag)
 
 			options := []fx.Option{
 				commonOptions,
+				fx.Supply(connectionOptions),
 				healthCheckModule(),
 				fx.Provide(func() api.ServiceInfo {
 					return api.ServiceInfo{


### PR DESCRIPTION
Add `fx.Supply(connectionOptions)` to `cmd/serve.go` to provide database connection options to the Fx container.

The Circuit Breaker storage module required `*bunconnect.ConnectionOptions` as an Fx dependency but it was not being supplied, preventing it from creating its DB connection. This change resolves the dependency injection issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-3960b50e-4c17-4473-bcea-fdc80e3b5da5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3960b50e-4c17-4473-bcea-fdc80e3b5da5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

