### PR TITLE
fix(deps): update expr-lang/expr to v1.17.7 to fix CVE GO-2025-4245

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.7
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.5.1
-	github.com/expr-lang/expr v1.17.6
+	github.com/expr-lang/expr v1.17.7
 	github.com/formancehq/formance-sdk-go/v3 v3.2.0
 	github.com/formancehq/go-libs/v3 v3.3.0
 	github.com/go-chi/chi/v5 v5.2.3

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731 h1:R/ZjJpjQKsZ6L/+Gf9WHbt31GG8NMVcpRqUE+1mMIyo=
 github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731/go.mod h1:M9R1FoZ3y//hwwnJtO51ypFGwm8ZfpxPT/ZLtO1mcgQ=
-github.com/expr-lang/expr v1.17.6 h1:1h6i8ONk9cexhDmowO/A64VPxHScu7qfSl2k8OlINec=
-github.com/expr-lang/expr v1.17.6/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
+github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

- Updates `github.com/expr-lang/expr` from v1.17.6 to v1.17.7
- Fixes **CVE GO-2025-4245**: Denial of Service via Unbounded Recursion in Builtin Functions

## CVE Details

- **Vulnerability**: Expr has Denial of Service via Unbounded Recursion in Builtin Functions
- **Severity**: Affects code paths in `internal/triggers/trigger.go` and `internal/triggers/expression.go`
- **More info**: https://pkg.go.dev/vuln/GO-2025-4245

## Additional Notes

There are 2 additional vulnerabilities in the Go standard library (`crypto/x509`) that require Go 1.24.11 to fix:
- GO-2025-4175: Improper application of excluded DNS name constraints
- GO-2025-4155: Excessive resource consumption when printing error string

These require upgrading the Go toolchain to version 1.24.11.

## Test plan

- [x] `go build ./...` passes
- [x] `govulncheck ./...` confirms GO-2025-4245 is resolved