### PR TITLE
fix(send): require connectorID for payment destinations

### DIFF
--- a/internal/workflow/activities/activity_transfer_initiation.go
+++ b/internal/workflow/activities/activity_transfer_initiation.go
@@ -34,6 +34,9 @@ type CreateTransferInitiationRequest struct {
 
 func (a Activities) CreateTransferInitiation(ctx context.Context, request CreateTransferInitiationRequest) error {
 	validated := request.WaitingValidation == nil || !*request.WaitingValidation
+	if request.ConnectorID == nil || *request.ConnectorID == "" {
+		return fmt.Errorf("connectorID is required")
+	}
 
 	activityInfo := activity.GetInfo(ctx)
 

--- a/internal/workflow/activities/activity_transfer_initiation_test.go
+++ b/internal/workflow/activities/activity_transfer_initiation_test.go
@@ -1,0 +1,63 @@
+package activities
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/formancehq/formance-sdk-go/v3"
+	"github.com/formancehq/go-libs/v3/pointer"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func TestCreateTransferInitiationSendsConnectorID(t *testing.T) {
+	var transferInitiationRequest map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		require.Equal(t, "/api/payments/transfer-initiations", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&transferInitiationRequest))
+		_, _ = w.Write([]byte(`{"data":{"id":"ti1","connectorID":"conn_routable","amount":100,"initialAmount":100,"asset":"USD/2","description":"routable PAYOUT","destinationAccountID":"dest","reference":"ref","status":"PROCESSING","type":"PAYOUT"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := sdk.New(sdk.WithServerURL(server.URL), sdk.WithClient(server.Client()))
+	activities := New(client)
+
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.CreateTransferInitiation)
+
+	_, err := env.ExecuteActivity(activities.CreateTransferInitiation, CreateTransferInitiationRequest{
+		Amount:      big.NewInt(100),
+		Asset:       pointer.For("USD/2"),
+		Provider:    pointer.For("routable"),
+		Type:        "PAYOUT",
+		Destination: pointer.For("dest"),
+		ConnectorID: pointer.For("conn_routable"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "conn_routable", transferInitiationRequest["connectorID"])
+}
+
+func TestCreateTransferInitiationRequiresConnectorID(t *testing.T) {
+	client := sdk.New()
+	activities := New(client)
+
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.CreateTransferInitiation)
+
+	_, err := env.ExecuteActivity(activities.CreateTransferInitiation, CreateTransferInitiationRequest{
+		Amount:      big.NewInt(100),
+		Asset:       pointer.For("USD/2"),
+		Provider:    pointer.For("routable"),
+		Type:        "PAYOUT",
+		Destination: pointer.For("dest"),
+	})
+	require.ErrorContains(t, err, "connectorID is required")
+}

--- a/internal/workflow/stages/send/schema_test.go
+++ b/internal/workflow/stages/send/schema_test.go
@@ -1,0 +1,91 @@
+package send
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/formancehq/formance-sdk-go/v3/pkg/models/shared"
+	"github.com/formancehq/orchestration/internal/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaymentDestinationRequiresConnectorID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid connectorID", func(t *testing.T) {
+		t.Parallel()
+
+		resolved, err := schema.Resolve(schema.Context{}, map[string]any{
+			"source": map[string]any{
+				"account": map[string]any{
+					"id": "source",
+				},
+			},
+			"destination": map[string]any{
+				"payment": map[string]any{
+					"psp":         "stripe",
+					"metadata":    "formanceAccountID",
+					"connectorID": "conn_123",
+				},
+			},
+			"amount": map[string]any{
+				"amount": float64(100),
+				"asset":  "USD/2",
+			},
+		}, "send")
+		require.NoError(t, err)
+
+		send := resolved.(*Send)
+		require.Equal(t, &Send{
+			Source: Source{
+				Account: &LedgerAccountSource{
+					ID:             "source",
+					Ledger:         "default",
+					ThroughAccount: "world",
+					AllowOverdraft: false,
+				},
+			},
+			Destination: Destination{
+				Payment: &PaymentDestination{
+					PSP:               "stripe",
+					Type:              "TRANSFER",
+					Metadata:          "formanceAccountID",
+					WaitingValidation: false,
+					ConnectorID:       stringPtr("conn_123"),
+				},
+			},
+			Amount: &shared.Monetary{
+				Amount: big.NewInt(100),
+				Asset:  "USD/2",
+			},
+		}, send)
+	})
+
+	t.Run("missing connectorID", func(t *testing.T) {
+		t.Parallel()
+
+		resolved, err := schema.Resolve(schema.Context{}, map[string]any{
+			"source": map[string]any{
+				"account": map[string]any{
+					"id": "source",
+				},
+			},
+			"destination": map[string]any{
+				"payment": map[string]any{
+					"psp":      "stripe",
+					"metadata": "formanceAccountID",
+				},
+			},
+			"amount": map[string]any{
+				"amount": float64(100),
+				"asset":  "USD/2",
+			},
+		}, "send")
+		require.NoError(t, err)
+		require.Error(t, schema.ValidateRequirements(resolved))
+	})
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/workflow/stages/send/send.go
+++ b/internal/workflow/stages/send/send.go
@@ -68,7 +68,7 @@ type PaymentDestination struct {
 	// Metadata is the key to look up in the source wallet/account metadata to get the destination account ID.
 	Metadata          string  `json:"metadata" spec:"default:formanceAccountID"`
 	WaitingValidation bool    `json:"waitingValidation" spec:"default:false"`
-	ConnectorID       *string `json:"connectorId,omitempty"`
+	ConnectorID       *string `json:"connectorID,omitempty" validate:"required"`
 }
 
 type Source struct {


### PR DESCRIPTION
## Summary
- require canonical connectorID on payment destinations in send stages
- fail CreateTransferInitiation early when connectorID is missing
- add coverage for schema validation and transfer initiation payloads

## Context
Payments requires connectorID to create transfer initiations. A workflow configured with only psp now fails validation instead of reaching Payments with a missing connectorID.

## Tests
- go test ./internal/workflow/activities ./internal/workflow/stages/send
- go test ./...