### PR TITLE
feat: pre-filter events before creating Temporal workflows

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -47,6 +47,7 @@ func workerOptions(cmd *cobra.Command) fx.Option {
 			stack,
 			stack,
 			temporalTaskQueue,
+			true,
 			topics,
 		),
 	)

--- a/internal/triggers/listener.go
+++ b/internal/triggers/listener.go
@@ -162,7 +162,8 @@ func handleMessage(
 			Event: *event,
 		}, trigger)
 		if execErr != nil {
-			if _, ok := execErr.(*serviceerror.WorkflowExecutionAlreadyStarted); ok {
+			var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+			if errors.As(execErr, &alreadyStarted) {
 				span.SetAttributes(attribute.Bool("duplicate-"+trigger.ID, true))
 				continue
 			}

--- a/internal/triggers/listener.go
+++ b/internal/triggers/listener.go
@@ -1,12 +1,15 @@
 package triggers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"go.temporal.io/api/enums/v1"
 
+	"github.com/formancehq/go-libs/v3/collectionutils"
 	"github.com/formancehq/orchestration/internal/tracer"
 	"github.com/formancehq/orchestration/internal/workflow"
 	"go.opentelemetry.io/otel/attribute"
@@ -20,6 +23,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/formancehq/go-libs/v3/publish"
 	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
 	"go.temporal.io/sdk/client"
 )
 
@@ -46,7 +50,53 @@ func getWorkflowIDFromEvent(event publish.EventMessage) *string {
 	}
 }
 
-func handleMessage(temporalClient client.Client, stack, taskIDPrefix, taskQueue string, msg *message.Message) error {
+func listMatchingTriggers(ctx context.Context, db *bun.DB, evaluator *expressionEvaluator, event publish.EventMessage) ([]Trigger, error) {
+	triggers := make([]Trigger, 0)
+	if err := db.NewSelect().
+		Model(&triggers).
+		Relation("Workflow").
+		Where("trigger.deleted_at is null").
+		Where("event = ?", event.Type).
+		Where("CASE WHEN trigger.version IS NULL THEN true ELSE trigger.version = ? END", event.Version).
+		Scan(ctx); err != nil {
+		return nil, err
+	}
+
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.Int("triggers-found", len(triggers)),
+		attribute.String("triggers-found-ids", strings.Join(collectionutils.Map(triggers, Trigger.GetID), ", ")),
+	)
+
+	matched := make([]Trigger, 0, len(triggers))
+	for _, trigger := range triggers {
+		if trigger.Filter != nil && *trigger.Filter != "" {
+			ok, err := evaluator.evalFilter(event.Payload, *trigger.Filter)
+			if err != nil {
+				logging.FromContext(ctx).Errorf("Error evaluating filter for trigger %s: %s", trigger.ID, err)
+				span.SetAttributes(attribute.String("filter-error-"+trigger.ID, err.Error()))
+				continue
+			}
+			if !ok {
+				continue
+			}
+		}
+		matched = append(matched, trigger)
+	}
+
+	span.SetAttributes(attribute.Int("triggers-matched", len(matched)))
+
+	return matched, nil
+}
+
+func handleMessage(
+	temporalClient client.Client,
+	db *bun.DB,
+	evaluator *expressionEvaluator,
+	stack, taskIDPrefix, taskQueue string,
+	includeSearchAttributes bool,
+	msg *message.Message,
+) error {
 	defer func() {
 		if e := recover(); e != nil {
 			fmt.Println(e)
@@ -67,7 +117,6 @@ func handleMessage(temporalClient client.Client, stack, taskIDPrefix, taskQueue 
 		}),
 		trace.WithAttributes(
 			attribute.String("event-id", msg.UUID),
-			attribute.Bool("duplicate", false),
 			attribute.String("event-type", event.Type),
 			attribute.String("event-version", event.Version),
 			attribute.String("event-payload", string(msg.Payload)),
@@ -80,38 +129,65 @@ func handleMessage(temporalClient client.Client, stack, taskIDPrefix, taskQueue 
 		}
 	}()
 
-	options := client.StartWorkflowOptions{
-		TaskQueue: taskQueue,
-		SearchAttributes: map[string]interface{}{
-			workflow.SearchAttributeStack: stack,
-		},
-	}
-	if ik := getWorkflowIDFromEvent(*event); ik != nil {
-		options.ID = taskIDPrefix + "-" + *ik
-		options.WorkflowIDReusePolicy = enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
-		options.WorkflowExecutionErrorWhenAlreadyStarted = true
+	matched, err := listMatchingTriggers(ctx, db, evaluator, *event)
+	if err != nil {
+		return errors.Wrap(err, "listing matching triggers")
 	}
 
-	_, err = temporalClient.ExecuteWorkflow(ctx, options, RunTrigger, ProcessEventRequest{
-		Event: *event,
-	})
-	if err != nil {
-		_, ok := err.(*serviceerror.WorkflowExecutionAlreadyStarted)
-		if ok {
-			span.SetAttributes(attribute.Bool("duplicate", true))
-			err = nil
-			return nil
+	if len(matched) == 0 {
+		return nil
+	}
+
+	objectID := getWorkflowIDFromEvent(*event)
+
+	for _, trigger := range matched {
+		searchAttributes := map[string]interface{}{
+			workflow.SearchAttributeStack: stack,
+		}
+		if includeSearchAttributes {
+			searchAttributes[workflow.SearchAttributeTriggerID] = trigger.ID
+		}
+
+		options := client.StartWorkflowOptions{
+			TaskQueue:        taskQueue,
+			SearchAttributes: searchAttributes,
+		}
+		if objectID != nil {
+			options.ID = taskIDPrefix + "-" + trigger.ID + "-" + *objectID
+			options.WorkflowIDReusePolicy = enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
+			options.WorkflowExecutionErrorWhenAlreadyStarted = true
+		}
+
+		_, execErr := temporalClient.ExecuteWorkflow(ctx, options, ExecuteTrigger, ProcessEventRequest{
+			Event: *event,
+		}, trigger)
+		if execErr != nil {
+			if _, ok := execErr.(*serviceerror.WorkflowExecutionAlreadyStarted); ok {
+				span.SetAttributes(attribute.Bool("duplicate-"+trigger.ID, true))
+				continue
+			}
+			logging.FromContext(ctx).Errorf("Error executing workflow for trigger %s: %s", trigger.ID, execErr)
+			err = execErr
+			return errors.Wrap(err, "executing workflow")
 		}
 	}
 
-	return errors.Wrap(err, "executing workflow")
+	return nil
 }
 
-func registerListener(r *message.Router, s message.Subscriber, temporalClient client.Client,
-	stack, taskIDPrefix, taskQueue string, topics []string) {
+func registerListener(
+	r *message.Router,
+	s message.Subscriber,
+	temporalClient client.Client,
+	db *bun.DB,
+	evaluator *expressionEvaluator,
+	stack, taskIDPrefix, taskQueue string,
+	includeSearchAttributes bool,
+	topics []string,
+) {
 	for _, topic := range topics {
 		r.AddConsumerHandler(fmt.Sprintf("listen-%s-events", topic), topic, s, func(msg *message.Message) error {
-			if err := handleMessage(temporalClient, stack, taskIDPrefix, taskQueue, msg); err != nil {
+			if err := handleMessage(temporalClient, db, evaluator, stack, taskIDPrefix, taskQueue, includeSearchAttributes, msg); err != nil {
 				logging.Errorf("Error executing workflow: %s", err)
 				return err
 			}

--- a/internal/triggers/listener_test.go
+++ b/internal/triggers/listener_test.go
@@ -1,0 +1,382 @@
+package triggers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/formancehq/go-libs/v3/bun/bunconnect"
+	"github.com/formancehq/go-libs/v3/bun/bundebug"
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v3/pointer"
+	"github.com/formancehq/go-libs/v3/publish"
+	"github.com/formancehq/orchestration/internal/storage"
+	"github.com/formancehq/orchestration/internal/temporalworker"
+	"github.com/formancehq/orchestration/internal/workflow"
+	"github.com/formancehq/orchestration/internal/workflow/stages"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	worker "go.temporal.io/sdk/worker"
+)
+
+func setupTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	hooks := make([]bun.QueryHook, 0)
+	if testing.Verbose() {
+		hooks = append(hooks, bundebug.NewQueryHook())
+	}
+
+	database := srv.NewDatabase(t)
+	db, err := bunconnect.OpenSQLDB(logging.TestingContext(), bunconnect.ConnectionOptions{
+		DatabaseSourceName: database.ConnString(),
+	}, hooks...)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	require.NoError(t, storage.Migrate(logging.TestingContext(), db))
+
+	return db
+}
+
+func insertNoOpWorkflow(t *testing.T, db *bun.DB) workflow.Workflow {
+	t.Helper()
+
+	w := workflow.New(workflow.Config{
+		Stages: []workflow.RawStage{{
+			"noop": map[string]any{},
+		}},
+	})
+	_, err := db.NewInsert().Model(&w).Exec(logging.TestingContext())
+	require.NoError(t, err)
+
+	return w
+}
+
+func insertTrigger(t *testing.T, db *bun.DB, workflowID, event string, version, filter *string) Trigger {
+	t.Helper()
+
+	trigger := Trigger{
+		TriggerData: TriggerData{
+			Event:      event,
+			Version:    version,
+			Filter:     filter,
+			WorkflowID: workflowID,
+		},
+		ID:        uuid.NewString(),
+		CreatedAt: time.Now().Round(time.Microsecond).UTC(),
+	}
+	_, err := db.NewInsert().Model(&trigger).Exec(logging.TestingContext())
+	require.NoError(t, err)
+
+	return trigger
+}
+
+func TestListMatchingTriggers(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name            string
+		triggers        func(t *testing.T, db *bun.DB, workflowID string)
+		event           publish.EventMessage
+		expectedMatched int
+	}
+
+	testCases := []testCase{
+		{
+			name:     "no triggers",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+			},
+			expectedMatched: 0,
+		},
+		{
+			name: "event type match",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, nil)
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+			},
+			expectedMatched: 1,
+		},
+		{
+			name: "event type mismatch",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "SAVED_PAYMENT", nil, nil)
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+			},
+			expectedMatched: 0,
+		},
+		{
+			name: "version match",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", pointer.For("v2"), nil)
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v2",
+			},
+			expectedMatched: 1,
+		},
+		{
+			name: "version mismatch",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", pointer.For("v1"), nil)
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v2",
+			},
+			expectedMatched: 0,
+		},
+		{
+			name: "nil version matches any",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, nil)
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v2",
+			},
+			expectedMatched: 1,
+		},
+		{
+			name: "filter match",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, pointer.For("event.amount > 50"))
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+				Payload: map[string]any{"amount": 100},
+			},
+			expectedMatched: 1,
+		},
+		{
+			name: "filter no match",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, pointer.For("event.amount > 50"))
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+				Payload: map[string]any{"amount": 10},
+			},
+			expectedMatched: 0,
+		},
+		{
+			name: "filter error skips trigger",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, pointer.For("event.missing.deep"))
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+				Payload: map[string]any{"amount": 10},
+			},
+			expectedMatched: 0,
+		},
+		{
+			name: "multiple triggers mixed",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				// This one matches: correct event type, no filter
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, nil)
+				// This one does not match: wrong event type
+				insertTrigger(t, db, workflowID, "SAVED_PAYMENT", nil, nil)
+				// This one does not match: filter evaluates to false
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, pointer.For("event.amount > 200"))
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+				Payload: map[string]any{"amount": 100},
+			},
+			expectedMatched: 1,
+		},
+		{
+			name: "soft deleted trigger excluded",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				trigger := insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, nil)
+				_, err := db.NewUpdate().
+					Model(&Trigger{}).
+					Where("id = ?", trigger.ID).
+					Set("deleted_at = ?", time.Now()).
+					Exec(logging.TestingContext())
+				require.NoError(t, err)
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+			},
+			expectedMatched: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := setupTestDB(t)
+			w := insertNoOpWorkflow(t, db)
+
+			tc.triggers(t, db, w.ID)
+
+			evaluator := NewDefaultExpressionEvaluator()
+			matched, err := listMatchingTriggers(logging.TestingContext(), db, evaluator, tc.event)
+			require.NoError(t, err)
+			require.Len(t, matched, tc.expectedMatched)
+		})
+	}
+}
+
+func TestHandleMessage(t *testing.T) {
+	t.Parallel()
+
+	setupWorker := func(t *testing.T, db *bun.DB) string {
+		t.Helper()
+
+		taskQueue := uuid.NewString()
+		workflowManager := workflow.NewManager(db, devServer.Client(), "test", taskQueue, false)
+
+		w := temporalworker.New(logging.Testing(), devServer.Client(), taskQueue,
+			[]temporalworker.DefinitionSet{
+				NewWorkflow("test", taskQueue, false).DefinitionSet(),
+				workflow.NewWorkflows("test", false).DefinitionSet(),
+				temporalworker.NewDefinitionSet().Append(temporalworker.Definition{
+					Name: "NoOp",
+					Func: (&stages.NoOp{}).GetWorkflow(),
+				}),
+			},
+			[]temporalworker.DefinitionSet{
+				workflow.NewActivities(publish.NoOpPublisher, db).DefinitionSet(),
+				NewActivities(db, workflowManager, NewDefaultExpressionEvaluator(), publish.NoOpPublisher).DefinitionSet(),
+			},
+			worker.Options{},
+		)
+		require.NoError(t, w.Start())
+		t.Cleanup(w.Stop)
+
+		return taskQueue
+	}
+
+	makeMessage := func(eventType, version string, payload any) *publish.EventMessage {
+		return &publish.EventMessage{
+			Date:    time.Now().Round(time.Second).UTC(),
+			App:     "test",
+			Version: version,
+			Type:    eventType,
+			Payload: payload,
+		}
+	}
+
+	t.Run("no match returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		db := setupTestDB(t)
+		_ = setupWorker(t, db)
+
+		event := makeMessage("NEW_TRANSACTION", "v1", map[string]any{})
+		msg := publish.NewMessage(logging.TestingContext(), *event)
+
+		evaluator := NewDefaultExpressionEvaluator()
+		err := handleMessage(devServer.Client(), db, evaluator, "test", "test", uuid.NewString(), false, msg)
+		require.NoError(t, err)
+	})
+
+	t.Run("one match creates workflow", func(t *testing.T) {
+		t.Parallel()
+
+		db := setupTestDB(t)
+		taskQueue := setupWorker(t, db)
+
+		w := insertNoOpWorkflow(t, db)
+		insertTrigger(t, db, w.ID, "NEW_TRANSACTION", nil, nil)
+
+		event := makeMessage("NEW_TRANSACTION", "v1", map[string]any{})
+		msg := publish.NewMessage(logging.TestingContext(), *event)
+
+		evaluator := NewDefaultExpressionEvaluator()
+		err := handleMessage(devServer.Client(), db, evaluator, "test", "test", taskQueue, false, msg)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			count, err := db.NewSelect().
+				Model((*Occurrence)(nil)).
+				Count(logging.TestingContext())
+			return err == nil && count == 1
+		}, 10*time.Second, 200*time.Millisecond)
+	})
+
+	t.Run("multiple matches create multiple workflows", func(t *testing.T) {
+		t.Parallel()
+
+		db := setupTestDB(t)
+		taskQueue := setupWorker(t, db)
+
+		w := insertNoOpWorkflow(t, db)
+		insertTrigger(t, db, w.ID, "NEW_TRANSACTION", nil, nil)
+		insertTrigger(t, db, w.ID, "NEW_TRANSACTION", nil, nil)
+
+		event := makeMessage("NEW_TRANSACTION", "v1", map[string]any{})
+		msg := publish.NewMessage(logging.TestingContext(), *event)
+
+		evaluator := NewDefaultExpressionEvaluator()
+		err := handleMessage(devServer.Client(), db, evaluator, "test", "test", taskQueue, false, msg)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			count, err := db.NewSelect().
+				Model((*Occurrence)(nil)).
+				Count(logging.TestingContext())
+			return err == nil && count == 2
+		}, 10*time.Second, 200*time.Millisecond)
+	})
+
+	t.Run("duplicate SAVED_PAYMENT is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		db := setupTestDB(t)
+		taskQueue := setupWorker(t, db)
+
+		w := insertNoOpWorkflow(t, db)
+		insertTrigger(t, db, w.ID, "SAVED_PAYMENT", nil, nil)
+
+		paymentID := uuid.NewString()
+		event := makeMessage("SAVED_PAYMENT", "v1", map[string]any{"id": paymentID})
+
+		evaluator := NewDefaultExpressionEvaluator()
+
+		// First call
+		msg1 := publish.NewMessage(logging.TestingContext(), *event)
+		err := handleMessage(devServer.Client(), db, evaluator, "test", "test", taskQueue, false, msg1)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			count, err := db.NewSelect().
+				Model((*Occurrence)(nil)).
+				Count(logging.TestingContext())
+			return err == nil && count == 1
+		}, 10*time.Second, 200*time.Millisecond)
+
+		// Second call with same event — should be skipped (duplicate workflow ID)
+		msg2 := publish.NewMessage(logging.TestingContext(), *event)
+		err = handleMessage(devServer.Client(), db, evaluator, "test", "test", taskQueue, false, msg2)
+		require.NoError(t, err)
+
+		// Still only 1 occurrence after a short wait
+		time.Sleep(2 * time.Second)
+		count, err := db.NewSelect().
+			Model((*Occurrence)(nil)).
+			Count(logging.TestingContext())
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+}

--- a/internal/triggers/main_test.go
+++ b/internal/triggers/main_test.go
@@ -23,7 +23,11 @@ func TestMain(m *testing.M) {
 		srv = pgtesting.CreatePostgresServer(t, docker.NewPool(t, logging.Testing()))
 
 		var err error
-		devServer, err = testsuite.StartDevServer(logging.TestingContext(), testsuite.DevServerOptions{})
+		devServer, err = testsuite.StartDevServer(logging.TestingContext(), testsuite.DevServerOptions{
+			ExtraArgs: []string{
+				"--search-attribute", "Stack=Text",
+			},
+		})
 		require.NoError(t, err)
 
 		t.Cleanup(func() {

--- a/internal/triggers/module.go
+++ b/internal/triggers/module.go
@@ -36,11 +36,12 @@ func NewModule(stack, taskQueue string) fx.Option {
 	)
 }
 
-func NewListenerModule(stack, taskIDPrefix, taskQueue string, topics []string) fx.Option {
+func NewListenerModule(stack, taskIDPrefix, taskQueue string, includeSearchAttributes bool, topics []string) fx.Option {
 	return fx.Options(
-		fx.Invoke(func(logger logging.Logger, r *message.Router, s message.Subscriber, temporalClient client.Client) {
+		fx.Invoke(func(logger logging.Logger, r *message.Router, s message.Subscriber,
+			temporalClient client.Client, db *bun.DB, evaluator *expressionEvaluator) {
 			logger.Infof("Listening events from topics: %s", strings.Join(topics, ","))
-			registerListener(r, s, temporalClient, stack, taskIDPrefix, taskQueue, topics)
+			registerListener(r, s, temporalClient, db, evaluator, stack, taskIDPrefix, taskQueue, includeSearchAttributes, topics)
 		}),
 	)
 }


### PR DESCRIPTION
## Summary

Cherry-picks #158 onto main.

- Move trigger matching (DB query + expr-lang filter evaluation) from RunTrigger Temporal workflow into the Watermill message handler
- Launch ExecuteTrigger directly for each matching trigger
- Return immediately when no triggers match an event
- Add observability span attributes for trigger filtering

## Cherry-picked commits

- 855c2b1252e604fa0015ef7dcfa15e0523d282c7
- 867072f5477e2edd8df7a83ef0410a73c8a21c0d
- ae1a67b38b96e45d21ce30ba4ac0205a1776b10d

## Test plan

- [x] go test -c ./internal/triggers
- [x] go build ./...
- [ ] go test ./internal/triggers/... (blocked locally: Docker daemon unavailable, /var/run/docker.sock connection refused)
