### PR TITLE
fix(triggers): repair broken name filter in ListTriggers (EN-1218)

### DIFF
--- a/internal/triggers/manager.go
+++ b/internal/triggers/manager.go
@@ -41,7 +41,7 @@ func (m *TriggerManager) ListTriggers(ctx context.Context, paramsQuery ListTrigg
 		func(query *bun.SelectQuery) *bun.SelectQuery {
 
 			if paramsQuery.Options.Name != "" {
-				query = query.Where("Name ILIKE '%?%';", paramsQuery.Options.Name)
+				query = query.Where("name ILIKE ?", "%"+paramsQuery.Options.Name+"%")
 			}
 			return query.Where("deleted_at is null")
 		})

--- a/internal/triggers/manager_test.go
+++ b/internal/triggers/manager_test.go
@@ -1,0 +1,74 @@
+package triggers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func insertNamedTrigger(t *testing.T, db *bun.DB, workflowID, name string) Trigger {
+	t.Helper()
+
+	trigger := Trigger{
+		TriggerData: TriggerData{
+			Name:       name,
+			Event:      "NEW_TRANSACTION",
+			WorkflowID: workflowID,
+		},
+		ID:        uuid.NewString(),
+		CreatedAt: time.Now().Round(time.Microsecond).UTC(),
+	}
+	_, err := db.NewInsert().Model(&trigger).Exec(logging.TestingContext())
+	require.NoError(t, err)
+
+	return trigger
+}
+
+func TestListTriggersNameFilter(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	w := insertNoOpWorkflow(t, db)
+	insertNamedTrigger(t, db, w.ID, "payment-processor")
+	insertNamedTrigger(t, db, w.ID, "ledger-sync")
+
+	manager := &TriggerManager{db: db}
+
+	listWithName := func(name string) []Trigger {
+		t.Helper()
+		cursor, err := manager.ListTriggers(logging.TestingContext(), ListTriggersQuery{
+			PageSize: 15,
+			Options:  ListTriggerParams{Name: name},
+		})
+		require.NoError(t, err)
+		return cursor.Data
+	}
+
+	t.Run("substring match", func(t *testing.T) {
+		got := listWithName("payment")
+		require.Len(t, got, 1)
+		require.Equal(t, "payment-processor", got[0].Name)
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		got := listWithName("LEDGER")
+		require.Len(t, got, 1)
+		require.Equal(t, "ledger-sync", got[0].Name)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		require.Empty(t, listWithName("does-not-exist"))
+	})
+
+	t.Run("no filter returns all", func(t *testing.T) {
+		cursor, err := manager.ListTriggers(logging.TestingContext(), ListTriggersQuery{
+			PageSize: 15,
+		})
+		require.NoError(t, err)
+		require.Len(t, cursor.Data, 2)
+	})
+}


### PR DESCRIPTION
## Problem (C4)

`ListTriggers` built its name filter as:
```go
query.Where("Name ILIKE '%?%';", paramsQuery.Options.Name)
```
bun substitutes the `?` placeholder **even inside the string literal**, so this renders as `Name ILIKE '%'foo'%';` — the value is spliced inside the quotes and the stray `;` lands in the middle of the WHERE clause (it is ANDed with `deleted_at is null`). Every `GET /triggers?name=...` request (v1 & v2) returned a 500.

## Fix

```go
query.Where("name ILIKE ?", "%"+paramsQuery.Options.Name+"%")
```
Proper parameterized predicate, wildcards on the argument.

## Test

Adds `TestListTriggersNameFilter` (integration) covering substring match, case-insensitive match, no-match, and the unfiltered case — none existed before.

Part of the deep-review remediation series. Severity: **CRITICAL**.