### PR TITLE
fix(wait_event): drain signals with a blocking Receive loop (EN-1223)

### DIFF
--- a/internal/workflow/stages/wait_event/run.go
+++ b/internal/workflow/stages/wait_event/run.go
@@ -7,16 +7,18 @@ import (
 
 func RunWaitEvent(ctx workflow.Context, waitEvent WaitEvent) error {
 	channel := workflow.GetSignalChannel(ctx, internalWorkflow.EventSignalName)
-	return workflow.Await(ctx, func() bool {
+	// Drain the signal channel one signal at a time until the expected event
+	// arrives. Using a blocking Receive loop (rather than ReceiveAsync inside
+	// an Await predicate) guarantees no buffered signal is consumed and
+	// dropped: an Await predicate is only evaluated once per workflow-task
+	// wakeup, so two signals delivered in the same task would leave the second
+	// one buffered with nothing left to re-wake the coroutine, blocking forever.
+	for {
 		var signal internalWorkflow.Event
-		ok := channel.ReceiveAsync(&signal)
-		if !ok {
-			return false
+		channel.Receive(ctx, &signal)
+		if signal.Name == waitEvent.Event {
+			return nil
 		}
-		if signal.Name != waitEvent.Event {
-			workflow.GetLogger(ctx).Debug("receive unexpected event", "event", signal.Name)
-			return false
-		}
-		return true
-	})
+		workflow.GetLogger(ctx).Debug("received unexpected event, still waiting", "event", signal.Name)
+	}
 }

--- a/internal/workflow/stages/wait_event/wait_event_test.go
+++ b/internal/workflow/stages/wait_event/wait_event_test.go
@@ -49,5 +49,29 @@ func TestWaitEvent(t *testing.T) {
 			}},
 			Name: "nominal",
 		},
+		{
+			Stage: WaitEvent{
+				Event: "test",
+			},
+			DelayedCallbacks: []stagestesting.DelayedCallback{{
+				Fn: func(environment *testsuite.TestWorkflowEnvironment) func() {
+					return func() {
+						// Two signals delivered in the same workflow task: a
+						// non-matching one followed by the matching one. The
+						// stage must consume the first, keep the second, and
+						// complete (the previous ReceiveAsync-in-Await
+						// implementation would drop the buffered match and hang).
+						environment.SignalWorkflow(workflow.EventSignalName, workflow.Event{
+							Name: "other",
+						})
+						environment.SignalWorkflow(workflow.EventSignalName, workflow.Event{
+							Name: "test",
+						})
+					}
+				},
+				Duration: 100 * time.Millisecond,
+			}},
+			Name: "ignores non-matching event delivered in the same task",
+		},
 	}...)
 }


### PR DESCRIPTION
## Problem (H3 — HIGH)

`RunWaitEvent` called `channel.ReceiveAsync` **inside a `workflow.Await` predicate**:
```go
return workflow.Await(ctx, func() bool {
    var signal internalWorkflow.Event
    ok := channel.ReceiveAsync(&signal)
    ...
})
```
An `Await` predicate is evaluated only **once per workflow-task wakeup**. If a non-matching signal and the matching signal arrive in the **same workflow task**, the predicate consumes the non-matching one, returns `false`, and the matching signal stays buffered with nothing left to re-wake the coroutine — the stage **blocks forever**. Non-matching events are also silently destroyed.

## Fix

Canonical blocking `Receive` loop that drains signals one at a time until the expected event arrives:
```go
for {
    var signal internalWorkflow.Event
    channel.Receive(ctx, &signal)
    if signal.Name == waitEvent.Event { return nil }
}
```

## Test

Adds a `TestWaitEvent` case signaling a non-matching event then the matching one **in the same task**; the stage completes (it would hang under the old implementation).

Severity: **HIGH**.