### PR TITLE
fix(workflow): run termination bookkeeping on a cancellation-safe context (EN-1224)

### DIFF
--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -10,6 +10,20 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+// terminationContext returns a context safe for running terminal bookkeeping
+// activities (status updates, termination events). When the workflow has been
+// cancelled, the supplied context is already cancelled and any activity started
+// on it fails immediately -- which would leave the instance/stage rows stuck
+// "running" and skip the termination event. In that case a disconnected context
+// is returned so the bookkeeping still runs.
+func terminationContext(ctx workflow.Context) workflow.Context {
+	if ctx.Err() == nil {
+		return ctx
+	}
+	disconnected, _ := workflow.NewDisconnectedContext(ctx)
+	return disconnected
+}
+
 type RawStage map[string]map[string]any
 
 type Config struct {
@@ -85,16 +99,20 @@ func (c *Config) run(ctx workflow.Context, instance Instance, variables map[stri
 		}
 		stage.SetTerminated(runError, workflow.Now(ctx).Round(time.Nanosecond))
 
-		err = workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		// Record the stage termination on a context that survives cancellation,
+		// otherwise a cancelled stage would never be marked terminated.
+		cleanupCtx := terminationContext(ctx)
+
+		err = workflow.ExecuteActivity(workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
 			StartToCloseTimeout: 10 * time.Second,
-		}), UpdateStageActivity, stage).Get(ctx, nil)
+		}), UpdateStageActivity, stage).Get(cleanupCtx, nil)
 		if err != nil {
 			return err
 		}
 
-		err = workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		err = workflow.ExecuteActivity(workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
 			StartToCloseTimeout: 10 * time.Second,
-		}), SendWorkflowStageTerminationEventActivity, instance, stage).Get(ctx, nil)
+		}), SendWorkflowStageTerminationEventActivity, instance, stage).Get(cleanupCtx, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/workflow/run.go
+++ b/internal/workflow/run.go
@@ -74,16 +74,21 @@ func (w Workflows) Run(ctx workflow.Context, i Input, instance Instance) error {
 		instance.SetTerminated(workflow.Now(ctx))
 	}
 
-	err = workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+	// Record the instance termination on a context that survives cancellation,
+	// otherwise a cancelled run would never be marked terminated and no
+	// termination event would be published.
+	cleanupCtx := terminationContext(ctx)
+
+	err = workflow.ExecuteActivity(workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
 		StartToCloseTimeout: 10 * time.Second,
-	}), UpdateInstanceActivity, instance).Get(ctx, nil)
+	}), UpdateInstanceActivity, instance).Get(cleanupCtx, nil)
 	if err != nil {
 		return err
 	}
 
-	err = workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+	err = workflow.ExecuteActivity(workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
 		StartToCloseTimeout: 10 * time.Second,
-	}), SendWorkflowTerminationEventActivity, instance).Get(ctx, nil)
+	}), SendWorkflowTerminationEventActivity, instance).Get(cleanupCtx, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem (H4 — HIGH)

When a `Run` workflow is **cancelled**, `config.run` returns a `CanceledError` and the run context is already cancelled. The terminal bookkeeping activities were then executed on that **cancelled** context:

- per stage: `UpdateStage` + `SendWorkflowStageTerminationEvent` (`config.go`)
- per instance: `UpdateInstance` + `SendWorkflowTerminationEvent` (`run.go`)

They failed immediately, so the instance/stage rows were left stuck **"running"** forever and no `FAILED_WORKFLOW(_STAGE)` event was published.

## Fix

Add `terminationContext(ctx)` which returns:
- the original context when it is still live (normal path — bookkeeping stays cancellable), or
- a `workflow.NewDisconnectedContext` when the workflow has been cancelled, so the bookkeeping still runs.

Use it for the terminal activities in both `run()` and `Run`.

## Testing

The normal path is unchanged and remains covered by the end-to-end `TestConfig`. A dedicated cancellation integration test would require registering a blocking stage inside the `workflow` internal test package, which creates an import cycle (`workflow → stages/... → workflow`); the fix is small and the cancellation behavior is asserted by reasoning. Happy to add an external-package test if preferred.

Severity: **HIGH**.