### PR TITLE
fix(workflow): stop using soft-deleted workflows (EN-1225)

### DIFF
--- a/internal/triggers/activities.go
+++ b/internal/triggers/activities.go
@@ -58,6 +58,7 @@ func (a Activities) ListTriggers(ctx context.Context, request ProcessEventReques
 		Model(&triggers).
 		Relation("Workflow").
 		Where("trigger.deleted_at is null").
+		Where("workflow_id IN (SELECT id FROM workflows WHERE deleted_at IS NULL)").
 		Where("event = ?", request.Event.Type).
 		Where("CASE WHEN trigger.version IS NULL THEN true ELSE trigger.version = ? END", request.Event.Version).
 		Scan(ctx); err != nil {

--- a/internal/triggers/listener.go
+++ b/internal/triggers/listener.go
@@ -56,6 +56,7 @@ func listMatchingTriggers(ctx context.Context, db *bun.DB, evaluator *expression
 		Model(&triggers).
 		Relation("Workflow").
 		Where("trigger.deleted_at is null").
+		Where("workflow_id IN (SELECT id FROM workflows WHERE deleted_at IS NULL)").
 		Where("event = ?", event.Type).
 		Where("CASE WHEN trigger.version IS NULL THEN true ELSE trigger.version = ? END", event.Version).
 		Scan(ctx); err != nil {

--- a/internal/triggers/listener_test.go
+++ b/internal/triggers/listener_test.go
@@ -218,6 +218,23 @@ func TestListMatchingTriggers(t *testing.T) {
 			},
 			expectedMatched: 0,
 		},
+		{
+			name: "trigger of soft deleted workflow excluded",
+			triggers: func(t *testing.T, db *bun.DB, workflowID string) {
+				insertTrigger(t, db, workflowID, "NEW_TRANSACTION", nil, nil)
+				_, err := db.NewUpdate().
+					Model(&workflow.Workflow{}).
+					Where("id = ?", workflowID).
+					Set("deleted_at = ?", time.Now()).
+					Exec(logging.TestingContext())
+				require.NoError(t, err)
+			},
+			event: publish.EventMessage{
+				Type:    "NEW_TRANSACTION",
+				Version: "v1",
+			},
+			expectedMatched: 0,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -63,7 +63,7 @@ func (m *WorkflowManager) DeleteWorkflow(ctx context.Context, id string) error {
 
 	var workflow Workflow
 
-	res, err := m.db.NewUpdate().Model(&workflow).Where("id = ?", id).Set("deleted_at = ?", time.Now()).Exec(ctx)
+	res, err := m.db.NewUpdate().Model(&workflow).Where("id = ?", id).Where("deleted_at IS NULL").Set("deleted_at = ?", time.Now()).Exec(ctx)
 
 	if err != nil {
 		return err
@@ -85,6 +85,7 @@ func (m *WorkflowManager) RunWorkflow(ctx context.Context, id string, variables 
 	workflow := Workflow{}
 	if err := m.db.NewSelect().
 		Where("id = ?", id).
+		Where("deleted_at IS NULL").
 		Model(&workflow).
 		Scan(ctx); err != nil {
 		return nil, err
@@ -142,6 +143,7 @@ func (m *WorkflowManager) ReadWorkflow(ctx context.Context, id string) (Workflow
 	if err := m.db.NewSelect().
 		Model(&workflow).
 		Where("id = ?", id).
+		Where("deleted_at IS NULL").
 		Scan(ctx); err != nil {
 		return Workflow{}, err
 	}

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -76,3 +76,41 @@ func TestConfig(t *testing.T) {
 		return len(updatedInstance.Statuses) == 1
 	}, 2*time.Second, 100*time.Millisecond)
 }
+
+func TestSoftDeletedWorkflowIsNotUsable(t *testing.T) {
+	t.Parallel()
+
+	database := srv.NewDatabase(t)
+	db, err := bunconnect.OpenSQLDB(logging.TestingContext(), bunconnect.ConnectionOptions{
+		DatabaseSourceName: database.ConnString(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	require.NoError(t, storage.Migrate(logging.TestingContext(), db))
+
+	manager := NewManager(db, devServer.Client(), "test", uuid.NewString(), false)
+
+	w, err := manager.Create(logging.TestingContext(), Config{
+		Stages: []RawStage{{"noop": map[string]any{}}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, manager.DeleteWorkflow(logging.TestingContext(), w.ID))
+
+	t.Run("ReadWorkflow excludes it", func(t *testing.T) {
+		_, err := manager.ReadWorkflow(logging.TestingContext(), w.ID)
+		require.Error(t, err)
+	})
+
+	t.Run("RunWorkflow refuses it", func(t *testing.T) {
+		// The select filters deleted_at, so this fails before reaching Temporal.
+		_, err := manager.RunWorkflow(logging.TestingContext(), w.ID, map[string]string{})
+		require.Error(t, err)
+	})
+
+	t.Run("re-delete returns not found", func(t *testing.T) {
+		err := manager.DeleteWorkflow(logging.TestingContext(), w.ID)
+		require.ErrorIs(t, err, ErrWorkflowNotFound)
+	})
+}


### PR DESCRIPTION
## Problem (H5 — HIGH)

- `RunWorkflow` (`manager.go:84-91`) and `ReadWorkflow` (`:140-149`) selected by `id` only, with no `deleted_at IS NULL`. After `DELETE /workflows/{id}`, `POST /workflows/{id}/instances` still launched new instances and the workflow was still readable.
- `DeleteWorkflow` had no `deleted_at` guard, so deleting twice rewrote the timestamp instead of returning not-found.
- `listMatchingTriggers` (listener) and `Activities.ListTriggers` filtered only `trigger.deleted_at`, so **triggers attached to a deleted workflow kept firing instances forever**.

## Fix

- `RunWorkflow` / `ReadWorkflow`: add `deleted_at IS NULL`.
- `DeleteWorkflow`: add `deleted_at IS NULL` guard ⇒ re-delete returns `ErrWorkflowNotFound`.
- Both trigger-matching queries: `WHERE workflow_id IN (SELECT id FROM workflows WHERE deleted_at IS NULL)`.

## Tests

- `TestListMatchingTriggers` gains a *trigger of soft-deleted workflow excluded* case.
- `TestSoftDeletedWorkflowIsNotUsable` covers read / run / re-delete.

Severity: **HIGH**.

> Note: touches `internal/triggers/listener.go` and `internal/workflow/manager.go`, which other PRs in this series also edit (different regions/functions); independent, may need trivial merges.