### PR TITLE
fix(worker): honour temporal-max-parallel-activities flag (EN-1228)

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -35,13 +35,18 @@ func workerOptions(cmd *cobra.Command) fx.Option {
 
 	stack, _ := cmd.Flags().GetString(stackFlag)
 	temporalTaskQueue, _ := cmd.Flags().GetString(temporal.TemporalTaskQueueFlag)
-	temporalMaxParallelActivities, _ := cmd.Flags().GetInt(temporal.TemporalMaxParallelActivitiesFlag)
+	// The flag is registered as a float64 in go-libs; reading it with GetInt
+	// silently fails and yields 0, so the configured limit was never applied.
+	temporalMaxParallelActivities, _ := cmd.Flags().GetFloat64(temporal.TemporalMaxParallelActivitiesFlag)
 	topics, _ := cmd.Flags().GetStringSlice(topicsFlag)
 
 	return fx.Options(
 		stackClientModule(cmd),
 		temporalworker.NewWorkerModule(temporalTaskQueue, worker.Options{
-			TaskQueueActivitiesPerSecond: float64(temporalMaxParallelActivities),
+			// "max parallel activities" caps concurrency, which maps to
+			// MaxConcurrentActivityExecutionSize, not the queue-wide rate limit
+			// TaskQueueActivitiesPerSecond it was previously wired to.
+			MaxConcurrentActivityExecutionSize: int(temporalMaxParallelActivities),
 		}),
 		triggers.NewListenerModule(
 			stack,


### PR DESCRIPTION
## Problem (H9 — HIGH)

```go
temporalMaxParallelActivities, _ := cmd.Flags().GetInt(temporal.TemporalMaxParallelActivitiesFlag)
...
worker.Options{ TaskQueueActivitiesPerSecond: float64(temporalMaxParallelActivities) }
```
The flag is registered as a **float64** in go-libs (`temporal/cli.go`). `GetInt` on a float64 flag returns an error (discarded) and `0`, so the worker option was always `0` (Temporal default = unlimited) — the operator-configured limit **never applied**. Separately, "max parallel activities" is a concurrency cap, which maps to `MaxConcurrentActivityExecutionSize`, not the queue-wide rate limit `TaskQueueActivitiesPerSecond`.

## Fix

- Read the flag with `GetFloat64`.
- Wire it to `MaxConcurrentActivityExecutionSize`.

**Behavioural note:** the default (10) now actually caps activity concurrency where it previously had no effect. Worth confirming the default suits production throughput.

Severity: **HIGH**.