### PR TITLE
fix(api): bound v1 list endpoints with a page size (EN-1230)

### DIFF
--- a/internal/api/v1/handler_list_instances.go
+++ b/internal/api/v1/handler_list_instances.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"net/http"
 
+	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
 	"github.com/formancehq/orchestration/internal/workflow"
 
 	api "github.com/formancehq/orchestration/internal/api"
@@ -13,7 +14,16 @@ import (
 func listInstances(backend api.Backend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
+		// Bound the query: without a page size, bunpaginate applies no LIMIT,
+		// loading the entire workflow_instances table per request.
+		pageSize, err := bunpaginate.GetPageSize(r)
+		if err != nil {
+			sharedapi.BadRequest(w, "VALIDATION", err)
+			return
+		}
+
 		runs, err := backend.ListInstances(r.Context(), workflow.ListInstancesQuery{
+			PageSize: pageSize,
 			Options: workflow.ListInstancesOptions{
 				WorkflowID: r.URL.Query().Get("workflowID"),
 				Running:    sharedapi.QueryParamBool(r, "running"),

--- a/internal/api/v1/handler_list_instances_test.go
+++ b/internal/api/v1/handler_list_instances_test.go
@@ -90,3 +90,38 @@ func TestListInstances(t *testing.T) {
 		require.Len(t, instances, 0)
 	})
 }
+
+func TestListInstancesIsBounded(t *testing.T) {
+	ctx := logging.TestingContext()
+
+	test(t, func(router *chi.Mux, m api.Backend, db *bun.DB) {
+		w := workflow.New(workflow.Config{})
+		_, err := db.NewInsert().Model(&w).Exec(ctx)
+		require.NoError(t, err)
+
+		for i := 0; i < 20; i++ {
+			instance := workflow.NewInstance(uuid.NewString(), w.ID)
+			_, err := db.NewInsert().Model(&instance).Exec(ctx)
+			require.NoError(t, err)
+		}
+
+		// Without a page size the default (15) bounds the result instead of
+		// loading the whole table.
+		req := httptest.NewRequest(http.MethodGet, "/instances", nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		instances := make([]workflow.Instance, 0)
+		sharedapi.ReadResponse(t, rec, &instances)
+		require.Len(t, instances, 15)
+
+		// An explicit page size is honoured.
+		req = httptest.NewRequest(http.MethodGet, "/instances?pageSize=5", nil)
+		rec = httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		instances = make([]workflow.Instance, 0)
+		sharedapi.ReadResponse(t, rec, &instances)
+		require.Len(t, instances, 5)
+	})
+}

--- a/internal/api/v1/handler_list_workflows.go
+++ b/internal/api/v1/handler_list_workflows.go
@@ -13,7 +13,17 @@ import (
 func listWorkflows(backend api2.Backend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		workflows, err := backend.ListWorkflows(r.Context(), bunpaginate.OffsetPaginatedQuery[any]{})
+		// Bound the query: without a page size, bunpaginate applies no LIMIT,
+		// loading the entire workflows table per request.
+		pageSize, err := bunpaginate.GetPageSize(r)
+		if err != nil {
+			api.BadRequest(w, "VALIDATION", err)
+			return
+		}
+
+		workflows, err := backend.ListWorkflows(r.Context(), bunpaginate.OffsetPaginatedQuery[any]{
+			PageSize: pageSize,
+		})
 		if err != nil {
 			api.InternalServerError(w, r, err)
 			return


### PR DESCRIPTION
## Problem (H11 — HIGH)

`v1` `listInstances` and `listWorkflows` passed a zero-value paginated query. In go-libs `bunpaginate`, `PageSize == 0` applies **no LIMIT**, so each request loaded the **entire** `workflow_instances` / `workflows` table into memory and serialized it — an unbounded query on tables that grow without limit in production.

## Fix

Read the page size with `bunpaginate.GetPageSize` (default 15, max 100, overridable via `?pageSize=`), exactly as the v2 handlers do, while keeping the v1 flat-array response shape.

**Behavioural note:** v1 list responses are now bounded to one page (default 15); clients needing more pass `?pageSize=` (up to 100). v1 has no cursor envelope, so this is the pragmatic bound for the legacy surface.

## Test

`TestListInstancesIsBounded`: 20 instances ⇒ default returns 15, `?pageSize=5` returns 5.

Severity: **HIGH**.