### PR TITLE
fix(storage): index triggers_occurrences(trigger_id, date) (EN-1231)

### DIFF
--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -172,6 +172,22 @@ var _migrations = []migrations.Migration{
 			return nil
 		},
 	},
+	{
+		// Migration 8 dropped the (trigger_id, event_id) primary key in favour
+		// of (id), leaving trigger_id unindexed. ListTriggersOccurrences filters
+		// WHERE trigger_id = ? and orders by date, so without this index every
+		// page is a sequential scan over an ever-growing table. Built
+		// CONCURRENTLY to avoid blocking writes during deploy.
+		Up: func(ctx context.Context, tx bun.IDB) error {
+			if _, err := tx.ExecContext(ctx, `
+				create index concurrently if not exists triggers_occurrences_trigger_id_date_idx
+				on triggers_occurrences (trigger_id, date);
+				`); err != nil {
+				return err
+			}
+			return nil
+		},
+	},
 }
 
 func Migrate(ctx context.Context, db *bun.DB) error {


### PR DESCRIPTION
## Problem (H12 — HIGH)

Migration 8 dropped the `(trigger_id, event_id)` primary key in favour of `(id)`, leaving `trigger_id` **unindexed**. `ListTriggersOccurrences` filters `WHERE trigger_id = ?` ordered by `date` (`internal/triggers/manager.go`), and `triggers_occurrences` gains one row per matched event — so every page request is a sequential scan over an ever-growing table, plus `OFFSET`.

## Fix

Add a migration creating the composite index `triggers_occurrences (trigger_id, date)`:
- built `CONCURRENTLY` to avoid blocking writes during deploy (the go-libs migrator runs each migration on a dedicated, non-transactional connection, so `CONCURRENTLY` is valid here — verified against the migration test harness);
- `IF NOT EXISTS` for idempotency.

## Test

Verified the full `storage.Migrate` chain runs cleanly (storage + triggers integration suites).

Severity: **HIGH**.